### PR TITLE
Allow further inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.2 - [2021-05-19]
+
+- allow further inputs
+
 ## 0.1.1 - [2020-08-19]
 
 - add typedoc

--- a/mod.ts
+++ b/mod.ts
@@ -23,14 +23,18 @@ export function setHandler(onCtrlC: () => void = fnExit): Disposable {
 
   Deno.setRaw(Deno.stdin.rid, true);
   disposed = false;
-
-  const data: Uint8Array = new Uint8Array(1);
-  Deno.stdin.read(data).then(() => {
-    if (disposed) return;
-    if (data[0] === 0x03) {
-      onCtrlC();
-    }
-  });
+  
+  function recursiveListen() {
+    const data: Uint8Array = new Uint8Array(1);
+    Deno.stdin.read(data).then(() => {
+      if (disposed) return;
+      if (data[0] === 0x03) {
+        onCtrlC();
+      }
+      recursiveListen();
+    });
+  }
+  recursiveListen();
 
   return {
     dispose: () => {


### PR DESCRIPTION
Should close https://github.com/justjavac/deno_ctrlc/issues/1.

Allow reading more than one input when TTY is in raw mode, thus enabling more inputs, until `CTRL`+`C` is pressed. I took the liberty of updating the changelog, feel free to ask me for naming changes or any edit.